### PR TITLE
Release: v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ envcli run go build -o envcli src/*
 #### **Docker for Windows**
 
 1. Install Docker for Windows from https://docs.docker.com/docker-for-windows/install/
-2. Install [EnvCLI](https://dl.bintray.com/envcli/golang/envcli/v0.2.1/EnvCLI-amd64.msi)
+2. Install [EnvCLI](https://dl.bintray.com/envcli/golang/envcli/v0.3.0/EnvCLI-amd64.msi)
 
 #### **Docker for Linux**
 
@@ -73,19 +73,19 @@ envcli run go build -o envcli src/*
 
 *32bit*
 ```
-$ curl -L -o /usr/local/bin/envcli https://dl.bintray.com/envcli/golang/envcli/v0.2.1/envcli_linux_386
+$ curl -L -o /usr/local/bin/envcli https://dl.bintray.com/envcli/golang/envcli/v0.3.0/envcli_linux_386
 $ chmod +x /usr/local/bin/envcli
 ```
 
 *64bit*
 ```
-$ curl -L -o /usr/local/bin/envcli https://dl.bintray.com/envcli/golang/envcli/v0.2.1/envcli_linux_amd64
+$ curl -L -o /usr/local/bin/envcli https://dl.bintray.com/envcli/golang/envcli/v0.3.0/envcli_linux_amd64
 $ chmod +x /usr/local/bin/envcli
 ```
 
 #### **Docker Toolbox (Legacy)**
 
-Install [EnvCLI](https://dl.bintray.com/envcli/golang/envcli/v0.2.1/EnvCLI-amd64.msi)
+Install [EnvCLI](https://dl.bintray.com/envcli/golang/envcli/v0.3.0/EnvCLI-amd64.msi)
 
 Now you have to configure a docker-machine for envcli: `docker-machine create envcli`
 

--- a/docs/changelog/0-3-0.md
+++ b/docs/changelog/0-3-0.md
@@ -4,6 +4,8 @@
 
 * support to pass ci variables by default into the containers #8 [Philipp Heuer]
 * provide a official docker image for use in gitlab / ci #9. [Philipp Heuer]
+* improved the documentation about the new features of this release
+* add support for command aliases `envcli run npm init` -> `npm init` but still use envcli in the background. See features/alias. #1
 
 ## Changes
 

--- a/docs/features/alias.md
+++ b/docs/features/alias.md
@@ -1,0 +1,10 @@
+# Aliases
+
+Getting tired of writing `envcli run ...` each time?
+
+We support aliases on:
+- Windows
+- Linux
+- Mac (untested, don't have one)
+
+Just write `envcli install-aliases` to install your global and project specific aliases within your PATH.

--- a/docs/features/ci.md
+++ b/docs/features/ci.md
@@ -1,0 +1,3 @@
+# CI Integration
+
+EnvCLI automatically detects execution in CI environments based on the env variable (CI=true) and will pass all variables into each container you use - so you can use variables like GITLAB_ or a BINTRAY_AUTH_TOKEN within the containers.

--- a/docs/features/docker.md
+++ b/docs/features/docker.md
@@ -1,0 +1,6 @@
+# EnvCLI
+
+EnvCLI has a official docker image that you can use for ci / simelar.
+
+GitHub: https://github.com/EnvCLI/docker-envcli
+DockerHub: https://hub.docker.com/r/envcli/envcli/tags/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,10 @@ pages:
 - Usage Examples:
     - 'Golang': 'examples/golang.md'
     - 'Node': 'examples/node.md'
+- Features:
+    - 'Aliases (omit envcli run)': 'features/alias.md'
+    - 'Official Docker Image': 'features/docker.md'
+    - 'Use in CI/CD with GitLab or simelar': 'features/ci.md'
 - Configuration:
     - 'EnvCLI.yml Specification': 'config/envcli-yml-specification.md'
     - 'Project Config': 'config/project-config.md'

--- a/scripts/alias.cmd
+++ b/scripts/alias.cmd
@@ -1,0 +1,7 @@
+@echo off
+
+REM find out which alias is called
+SET aliasFor=%~n0
+
+REM call envcli for the alias and pass all arguments
+envcli run %aliasFor% %*

--- a/scripts/alias.sh
+++ b/scripts/alias.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# find out which alias is called
+aliasFor=$(echo $(basename $(readlink -nf $0)) | cut -f 1 -d '.')
+
+# call envcli for the alias and pass all arguments
+envcli run $aliasFor $@

--- a/src/app.go
+++ b/src/app.go
@@ -228,6 +228,50 @@ func main() {
 				},
 			},
 			/**
+			 * Command: install-aliases
+			 */
+			{
+				Name:    "install-aliases",
+				Aliases: []string{},
+				Usage:   "installs aliases for the global / project scoped commands",
+				Action: func(c *cli.Context) error {
+					log.Debugf("Installing aliases ...")
+
+					// create global-scoped aliases
+					configurationLoader := ConfigurationLoader{}
+					var globalConfigPath = getOrDefault(propConfig.Properties, "global-configuration-path", defaultConfigurationDirectory)
+					log.Debugf("Will load the global configuration from [%s].", globalConfigPath)
+					globalConfig, _ := configurationLoader.loadProjectConfig(globalConfigPath + "/.envcli.yml")
+
+					for _, element := range globalConfig.Images {
+						element.Scope = "Global"
+						log.Debugf("Created aliases for %s [Scope: %s]", element.Name, element.Scope)
+
+						// for each provided command
+						for _, currentCommand := range element.Provides {
+							installAlias(currentCommand, element.Scope)
+						}
+					}
+
+					// create project-scoped aliases
+					var projectDirectory = configurationLoader.getProjectDirectory()
+					log.Debugf("Project Directory: %s", projectDirectory)
+					projectConfig, _ := configurationLoader.loadProjectConfig(projectDirectory + "/.envcli.yml")
+
+					for _, element := range projectConfig.Images {
+						element.Scope = "Project"
+						log.Debugf("Created aliases for %s [Scope: %s]", element.Name, element.Scope)
+
+						// for each provided command
+						for _, currentCommand := range element.Provides {
+							installAlias(currentCommand, element.Scope)
+						}
+					}
+
+					return nil
+				},
+			},
+			/**
 			 * Command: config
 			 */
 			{

--- a/src/app.go
+++ b/src/app.go
@@ -234,37 +234,51 @@ func main() {
 				Name:    "install-aliases",
 				Aliases: []string{},
 				Usage:   "installs aliases for the global / project scoped commands",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:    "scope",
+						Aliases: []string{"s"},
+						Value:   "all",
+						Usage:   "Install aliases for the specified scope (project/global or all)",
+					},
+				},
 				Action: func(c *cli.Context) error {
 					log.Debugf("Installing aliases ...")
+					scopeFilter := c.String("scope")
+
+					configurationLoader := ConfigurationLoader{}
 
 					// create global-scoped aliases
-					configurationLoader := ConfigurationLoader{}
-					var globalConfigPath = getOrDefault(propConfig.Properties, "global-configuration-path", defaultConfigurationDirectory)
-					log.Debugf("Will load the global configuration from [%s].", globalConfigPath)
-					globalConfig, _ := configurationLoader.loadProjectConfig(globalConfigPath + "/.envcli.yml")
+					if scopeFilter == "all" || scopeFilter == "global" {
+						var globalConfigPath = getOrDefault(propConfig.Properties, "global-configuration-path", defaultConfigurationDirectory)
+						log.Debugf("Will load the global configuration from [%s].", globalConfigPath)
+						globalConfig, _ := configurationLoader.loadProjectConfig(globalConfigPath + "/.envcli.yml")
 
-					for _, element := range globalConfig.Images {
-						element.Scope = "Global"
-						log.Debugf("Created aliases for %s [Scope: %s]", element.Name, element.Scope)
+						for _, element := range globalConfig.Images {
+							element.Scope = "Global"
+							log.Debugf("Created aliases for %s [Scope: %s]", element.Name, element.Scope)
 
-						// for each provided command
-						for _, currentCommand := range element.Provides {
-							installAlias(currentCommand, element.Scope)
+							// for each provided command
+							for _, currentCommand := range element.Provides {
+								installAlias(currentCommand, element.Scope)
+							}
 						}
 					}
 
 					// create project-scoped aliases
-					var projectDirectory = configurationLoader.getProjectDirectory()
-					log.Debugf("Project Directory: %s", projectDirectory)
-					projectConfig, _ := configurationLoader.loadProjectConfig(projectDirectory + "/.envcli.yml")
+					if scopeFilter == "all" || scopeFilter == "project" {
+						var projectDirectory = configurationLoader.getProjectDirectory()
+						log.Debugf("Project Directory: %s", projectDirectory)
+						projectConfig, _ := configurationLoader.loadProjectConfig(projectDirectory + "/.envcli.yml")
 
-					for _, element := range projectConfig.Images {
-						element.Scope = "Project"
-						log.Debugf("Created aliases for %s [Scope: %s]", element.Name, element.Scope)
+						for _, element := range projectConfig.Images {
+							element.Scope = "Project"
+							log.Debugf("Created aliases for %s [Scope: %s]", element.Name, element.Scope)
 
-						// for each provided command
-						for _, currentCommand := range element.Provides {
-							installAlias(currentCommand, element.Scope)
+							// for each provided command
+							for _, currentCommand := range element.Provides {
+								installAlias(currentCommand, element.Scope)
+							}
 						}
 					}
 

--- a/src/app.go
+++ b/src/app.go
@@ -129,7 +129,6 @@ func main() {
 					globalConfig, _ := configurationLoader.loadProjectConfig(globalConfigPath + "/.envcli.yml")
 
 					// load project configuration
-					configurationLoader := ConfigurationLoader{}
 					var projectDirectory = configurationLoader.getProjectDirectory()
 					if projectDirectory == "" {
 						log.Warnf("No project configuration found in current or parent directories. Only the global commands are available.")
@@ -297,7 +296,6 @@ func main() {
 						Name: "set",
 						Action: func(c *cli.Context) error {
 							// Load Config
-							configurationLoader := ConfigurationLoader{}
 							propConfig, _ := configurationLoader.loadPropertyConfig(defaultConfigurationDirectory + "/.envclirc")
 
 							// Check Parameters

--- a/src/feature-aliases.go
+++ b/src/feature-aliases.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	log "github.com/sirupsen/logrus" // imports as package "log"
+	"os"
+	"runtime"
+)
+
+/**
+ * CLI Command Passthru with input/output
+ */
+func installAlias(command string, scope string) error {
+	log.Debugf("Creating alias for command: %s [Scope: %s]", command, scope)
+
+	// download alias script for each used command
+	if runtime.GOOS == "linux" {
+		log.Debugf("Detected Linux - Will place bash scripts into PATH ...")
+		aliasScriptURL := "https://raw.githubusercontent.com/EnvCLI/EnvCLI/develop/scripts/alias.sh"
+		aliasScriptFilepath := configurationLoader.getExecutionDirectory() + "/" + command + ".sh"
+
+		err := DownloadFile(aliasScriptFilepath, aliasScriptURL)
+		if err != nil {
+			log.Errorf("Can't create alias [%s], download failed.", command)
+			panic(err)
+		} else {
+			log.Debugf("Created alias for [%s]!", command)
+
+			// set execute permissions
+			chmodErr := os.Chmod(aliasScriptFilepath, 0744)
+			if chmodErr != nil {
+				log.Errorf("Failed to make the alias script for [%s] executable!", command)
+			} else {
+				log.Debugf("Made alias script for [%s] executable!", command)
+			}
+		}
+	} else {
+		log.Errorf("Can't create alias for [%s]. Aliases aren't supported on %s yet!", command, runtime.GOOS)
+	}
+
+	return nil
+}

--- a/src/feature-aliases.go
+++ b/src/feature-aliases.go
@@ -16,7 +16,7 @@ func installAlias(command string, scope string) error {
 	if runtime.GOOS == "linux" {
 		log.Debugf("Detected Linux - Will place bash scripts into PATH ...")
 		aliasScriptURL := "https://raw.githubusercontent.com/EnvCLI/EnvCLI/develop/scripts/alias.sh"
-		aliasScriptFilepath := configurationLoader.getExecutionDirectory() + "/" + command + ".sh"
+		aliasScriptFilepath := configurationLoader.getExecutionDirectory() + "/" + command
 
 		err := DownloadFile(aliasScriptFilepath, aliasScriptURL)
 		if err != nil {

--- a/src/feature-aliases.go
+++ b/src/feature-aliases.go
@@ -13,7 +13,7 @@ func installAlias(command string, scope string) error {
 	log.Debugf("Creating alias for command: %s [Scope: %s]", command, scope)
 
 	// download alias script for each used command
-	if runtime.GOOS == "linux" {
+	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
 		log.Debugf("Detected Linux - Will place bash scripts into PATH ...")
 		aliasScriptURL := "https://raw.githubusercontent.com/EnvCLI/EnvCLI/develop/scripts/alias.sh"
 		aliasScriptFilepath := configurationLoader.getExecutionDirectory() + "/" + command
@@ -32,6 +32,18 @@ func installAlias(command string, scope string) error {
 			} else {
 				log.Debugf("Made alias script for [%s] executable!", command)
 			}
+		}
+	} else if runtime.GOOS == "windows" {
+		log.Debugf("Detected Windows - Will place cmd scripts into PATH ...")
+		aliasScriptURL := "https://raw.githubusercontent.com/EnvCLI/EnvCLI/develop/scripts/alias.cmd"
+		aliasScriptFilepath := configurationLoader.getExecutionDirectory() + "/" + command + ".cmd"
+
+		err := DownloadFile(aliasScriptFilepath, aliasScriptURL)
+		if err != nil {
+			log.Errorf("Can't create alias [%s], download failed.", command)
+			panic(err)
+		} else {
+			log.Debugf("Created alias for [%s]!", command)
 		}
 	} else {
 		log.Errorf("Can't create alias for [%s]. Aliases aren't supported on %s yet!", command, runtime.GOOS)

--- a/src/feature-aliases.go
+++ b/src/feature-aliases.go
@@ -15,7 +15,7 @@ func installAlias(command string, scope string) error {
 	// download alias script for each used command
 	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
 		log.Debugf("Detected Linux - Will place bash scripts into PATH ...")
-		aliasScriptURL := "https://raw.githubusercontent.com/EnvCLI/EnvCLI/develop/scripts/alias.sh"
+		aliasScriptURL := "https://raw.githubusercontent.com/EnvCLI/EnvCLI/" + appVersion + "/scripts/alias.sh"
 		aliasScriptFilepath := configurationLoader.getExecutionDirectory() + "/" + command
 
 		err := DownloadFile(aliasScriptFilepath, aliasScriptURL)
@@ -35,7 +35,7 @@ func installAlias(command string, scope string) error {
 		}
 	} else if runtime.GOOS == "windows" {
 		log.Debugf("Detected Windows - Will place cmd scripts into PATH ...")
-		aliasScriptURL := "https://raw.githubusercontent.com/EnvCLI/EnvCLI/develop/scripts/alias.cmd"
+		aliasScriptURL := "https://raw.githubusercontent.com/EnvCLI/EnvCLI/" + appVersion + "/scripts/alias.cmd"
 		aliasScriptFilepath := configurationLoader.getExecutionDirectory() + "/" + command + ".cmd"
 
 		err := DownloadFile(aliasScriptFilepath, aliasScriptURL)

--- a/src/util.go
+++ b/src/util.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	log "github.com/sirupsen/logrus" // imports as package "log"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"reflect"
@@ -130,4 +132,32 @@ func detectCIEnvironment() (val bool) {
 	}
 
 	return false
+}
+
+/**
+ * DownloadFile will download a url to a local file.
+ */
+func DownloadFile(filepath string, url string) error {
+
+	// Create the file
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Write the body to file
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
# Release - 🚀 v0.3.0 🚀 (2018-10-06)

## Features
* support to pass ci variables by default into the containers #8 [Philipp Heuer]
* provide a official docker image for use in gitlab / ci #9. [Philipp Heuer]
* improved the documentation about the new features of this release
* add support for command aliases `envcli run npm init` -> `npm init` but still use envcli in the background. See features/alias. #1

## Changes
* fix to detect ci environments that can't use a tty (CI)

## Breaking Changes
-/-

## Migration
-/-